### PR TITLE
Update build.sbt to use Lab4 filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ lazy val root = (project in file("."))
     libraryDependencies += scalatest % Lab4,
     testOptions in TestAll := Seq(Tests.Filter(allFilter)),
     // CHANGE THE LINE BELOW FOR EACH LAB!!!! Use the matching filter
-    testOptions in Test := Seq(Tests.Filter(lab3Filter)),
+    testOptions in Test := Seq(Tests.Filter(lab4Filter)),
     testOptions in Grader := Seq(Tests.Filter(graderFilter)),
     testOptions in Lab1 := Seq(Tests.Filter(lab1Filter)),
     testOptions in Lab2 := Seq(Tests.Filter(lab2Filter)),


### PR DESCRIPTION
Some students on discord were complaining about having to type out "Lab4 / ..." to run simulations. This patch will remove that need.